### PR TITLE
fix: Proper get_battery_voltage() with ADC function

### DIFF
--- a/core/modules/peripherals.py
+++ b/core/modules/peripherals.py
@@ -9,7 +9,7 @@ class Periph:
     """
     Class for inculding periheral hardware functions of picocell module.
     """
-    battery_voltage_pin = ADC(29)
+    battery_voltage_pin = Pin(29, Pin.IN)
     battery_charge_status_pin = Pin(25, Pin.IN)
     user_button_pin = Pin(26, Pin.IN)
     neopixel_pin = Pin(10, Pin.OUT)
@@ -60,7 +60,8 @@ class Periph:
         voltage : float
             Battery voltage
         """
-        raw_16_bit = self.battery_voltage_pin.read_u16()
+        adc_module = ADC(self.battery_voltage_pin)
+        raw_16_bit = adc_module.read_u16()
         value_in_volts = (raw_16_bit / 65535) * 3.3
         return value_in_volts
 


### PR DESCRIPTION
`Pin.value()` method can be only used for digital signals. `ADC` class needs to be set in order to read a analogue voltage value. `ADC` class only provides two methods as it says in [this MicroPython doc](https://docs.micropython.org/en/latest/library/machine.ADC.html):
* `ADC.read_u16()`: which works perfectly, and returns a value between 0-65535.
* `ADC.read_uv()`: does not work on our RP2040 microcontroller.

Note that, `machine` module does not have a `ADC.read_uv()` method as we see:
```python
>>> dir(machine.ADC)
['__class__', '__name__', '__bases__', '__dict__', 'CORE_TEMP', 'read_u16']
```

Check out [this tutorial](https://www.upesy.com/blogs/tutorials/micropython-raspberry-pi-pico-adc-usage-measure-voltage) for further information.