### PR TITLE
fix: Resolve errors in `network.py` file

### DIFF
--- a/core/modules/network.py
+++ b/core/modules/network.py
@@ -82,7 +82,8 @@ class Network:
             Result that includes "status" and "response" keys
         """
         desired_reponses = ["+CREG: 0,1", "+CREG: 0,5"]
-        return self.atcom.send_at_comm("AT+CREG?", desired_reponses)
+        fault_responses = "+CREG: 0,2"
+        return self.atcom.send_at_comm("AT+CREG?", desired=desired_reponses, fault=fault_responses)
 
     def get_operator_information(self):
         """


### PR DESCRIPTION
* get_apn() method was checking for wrong cid number (=2), it is changed to process for every CIDs.
* When "+CREG: 0,2" returns from the modem, `check_network_registration()` method was returning Status.TIMEOUT. It has changed to ERROR.