### PR TITLE
hotfix: Add mock class for machine.ADC module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,10 @@ class I2C:
 
     def scan(self, *args, **kwargs):
         pass
+
+class ADC:
+    def __init__(self, *args, **kwargs):
+        pass
 """
 
 MOCK_NEOPIXEL_PY = """


### PR DESCRIPTION
Added an ADC class in machine module to prevent import errors in test files.