### PR TITLE
fix: Change echo method name

### DIFF
--- a/core/modem.py
+++ b/core/modem.py
@@ -62,4 +62,4 @@ class Modem:
             self.base.power_on_off()
         self.base.wait_until_status_on()
         self.base.wait_until_modem_ready_to_communicate()
-        self.base.turn_off_at_echo()
+        self.base.set_echo_off()


### PR DESCRIPTION
After removing the duplicate method in `core.modules.base`, we forgot to change the name in `modem.py` file. On this PR, it has been changed to new name.