### PR TITLE
Refactor: gps data format change

### DIFF
--- a/pico_lte/modules/gps.py
+++ b/pico_lte/modules/gps.py
@@ -106,5 +106,35 @@ class GPS:
         result = self.atcom.send_at_comm(command, desired)
 
         if result["status"] == Status.SUCCESS:
-            return get_desired_data(result, desired, data_index=[1, 2])
+            data = get_desired_data(result, desired, data_index=[1, 2])
+            data["value"]["Lat-Lon"][0] = self.nmea_to_decimal(
+                data["value"]["Lat-Lon"][0]
+            )
+            data["value"]["Lat-Lon"][1] = self.nmea_to_decimal(
+                data["value"]["Lat-Lon"][1]
+            )
+            return data
         return result
+
+    def nmea_to_decimal(self, nmea_data):
+        """
+        Convert NMEA data to decimal.
+
+        Parameters
+        ----------
+        nmea_data : str
+            NMEA data to be converted to decimal.
+
+        Returns
+        -------
+        str
+            Converted decimal data in string format.
+        """
+        value = float(nmea_data[0:-1])
+        integer = int(value * 0.01)
+        degree = integer + ((value - (integer * 100)) / 60)
+
+        if nmea_data[-1] == "S" or nmea_data[-1] == "W":
+            degree *= -1.0
+
+        return str(degree)

--- a/pico_lte/modules/gps.py
+++ b/pico_lte/modules/gps.py
@@ -107,12 +107,8 @@ class GPS:
 
         if result["status"] == Status.SUCCESS:
             data = get_desired_data(result, desired, data_index=[1, 2])
-            data["value"]["Lat-Lon"][0] = self.nmea_to_decimal(
-                data["value"]["Lat-Lon"][0]
-            )
-            data["value"]["Lat-Lon"][1] = self.nmea_to_decimal(
-                data["value"]["Lat-Lon"][1]
-            )
+            data["value"][0] = self.nmea_to_decimal(data["value"][0])
+            data["value"][1] = self.nmea_to_decimal(data["value"][1])
             return data
         return result
 

--- a/pico_lte/modules/gps.py
+++ b/pico_lte/modules/gps.py
@@ -101,36 +101,10 @@ class GPS:
             * "response" --> Response of the command
             * "value" --> [lat,lon] Location of the device
         """
-        command = "AT+QGPSLOC?"
+        command = "AT+QGPSLOC=2"
         desired = "+QGPSLOC: "
         result = self.atcom.send_at_comm(command, desired)
 
         if result["status"] == Status.SUCCESS:
-            data = get_desired_data(result, desired, data_index=[1, 2])
-            data["value"][0] = self.nmea_to_decimal(data["value"][0])
-            data["value"][1] = self.nmea_to_decimal(data["value"][1])
-            return data
+            return get_desired_data(result, desired, data_index=[1, 2])
         return result
-
-    def nmea_to_decimal(self, nmea_data):
-        """
-        Convert NMEA data to decimal.
-
-        Parameters
-        ----------
-        nmea_data : str
-            NMEA data to be converted to decimal.
-
-        Returns
-        -------
-        str
-            Converted decimal data in string format.
-        """
-        value = float(nmea_data[0:-1])
-        integer = int(value * 0.01)
-        degree = integer + ((value - (integer * 100)) / 60)
-
-        if nmea_data[-1] == "S" or nmea_data[-1] == "W":
-            degree *= -1.0
-
-        return str(degree)

--- a/tests/test_modules_gps.py
+++ b/tests/test_modules_gps.py
@@ -31,7 +31,9 @@ class TestGPS:
     @staticmethod
     def mock_send_at_comm(mocker, responses_to_return):
         """This is a wrapper function to repeated long mocker.patch() statements."""
-        return mocker.patch("pico_lte.utils.atcom.ATCom.send_at_comm", return_value=responses_to_return)
+        return mocker.patch(
+            "pico_lte.utils.atcom.ATCom.send_at_comm", return_value=responses_to_return
+        )
 
     def test_constructor(self, gps):
         """This method tests the __init__ constructor."""
@@ -68,7 +70,8 @@ class TestGPS:
 
     @pytest.mark.parametrize(
         "mocked_response",
-        [{"status": Status.SUCCESS, "response": ["+CME ERROR: 504"]}] + default_response_types(),
+        [{"status": Status.SUCCESS, "response": ["+CME ERROR: 504"]}]
+        + default_response_types(),
     )
     def test_turn_on_default_parameters(self, mocker, gps, mocked_response):
         """This method tests the turn_on() with predefined parameters."""
@@ -90,7 +93,9 @@ class TestGPS:
         mocking = TestGPS.mock_send_at_comm(mocker, mocked_response)
         result = gps.turn_on(mode, accuracy, fix_count, fix_rate)
 
-        mocking.assert_called_once_with(f"AT+QGPS={mode},{accuracy},{fix_count},{fix_rate}")
+        mocking.assert_called_once_with(
+            f"AT+QGPS={mode},{accuracy},{fix_count},{fix_rate}"
+        )
         assert result == mocked_response
 
     @pytest.mark.parametrize("mocked_response", default_response_types())
@@ -108,7 +113,7 @@ class TestGPS:
             {
                 "status": Status.SUCCESS,
                 "response": [
-                    "+QGPSLOC: 061951.00,3150.7223N,11711.9293E,0.7,62.2,2,0.00,0.0,0.0,110513,09",
+                    "+QGPSLOC: 061951.00,41.02044,28.99797,0.7,62.2,2,0.00,0.0,0.0,110513,09",
                     "OK",
                 ],
             },
@@ -121,9 +126,9 @@ class TestGPS:
         mocking = TestGPS.mock_send_at_comm(mocker, mocked_response)
         result = gps.get_location()
 
-        mocking.assert_called_once_with("AT+QGPSLOC?", "+QGPSLOC: ")
+        mocking.assert_called_once_with("AT+QGPSLOC=2", "+QGPSLOC: ")
 
         if result["status"] == Status.SUCCESS:
-            assert result["value"] == ["3150.7223N", "11711.9293E"]
+            assert result["value"] == ["41.02044", "28.99797"]
         assert result["status"] == mocked_response["status"]
         assert result["response"] == mocked_response["response"]


### PR DESCRIPTION
## What
GPS value has been changed to decimal format from NMEA format.

## Why
Decimal format is easier to understand and is more commonly used.

## How
The <mode> parameter of "AT+QGPSLOC" command has been changed to attain GPS values in decimal format.

## Testing
The unit test file for GPS has been updated and ran successfully.