### PR TITLE
fix: Use standard \r\n for the http custom header to avoid problem get/post to http servers

### DIFF
--- a/examples/http/get_with_custom_header.py
+++ b/examples/http/get_with_custom_header.py
@@ -43,14 +43,14 @@ else:
 
 
 # Custom header
-HEADER = "\n".join(
+HEADER = "\r\n".join(
     [
         f"GET {query} HTTP/1.1",
         f"Host: {host}",
         "Custom-Header-Name: Custom-Data",
         "Content-Type: application/json",
-        "Content-Length: 0\n",
-        "\n\n",
+        "Content-Length: 0",
+        "\r\n",
     ]
 )
 

--- a/examples/http/post_with_custom_header.py
+++ b/examples/http/post_with_custom_header.py
@@ -46,14 +46,14 @@ DATA_TO_POST = {"message": "PicoLTE HTTP POST Example with Custom Header"}
 payload = json.dumps(DATA_TO_POST)
 
 # Custom header
-HEADER = "\n".join(
+HEADER = "\r\n".join(
     [
         f"POST /{query} HTTP/1.1",
         f"Host: {host}",
         "Custom-Header-Name: Custom-Data",
         "Content-Type: application/json",
-        f"Content-Length: {len(payload)+1}",
-        "\n\n",
+        f"Content-Length: {len(payload) + 1}",
+        "\r\n",
     ]
 )
 


### PR DESCRIPTION
fix: Use standard \r\n for the http custom header to avoid problem get/post to http servers